### PR TITLE
send complete track list to player

### DIFF
--- a/vamp/src/pconley/vamp/LibraryActivity.java
+++ b/vamp/src/pconley/vamp/LibraryActivity.java
@@ -28,6 +28,7 @@ import android.widget.Toast;
 public class LibraryActivity extends Activity {
 
 	private ListView trackListView;
+	private long[] trackIds;
 
 	/*
 	 * Receive status messages from the player. Only necessary to show errors.
@@ -66,9 +67,9 @@ public class LibraryActivity extends Activity {
 
 				Intent intent = new Intent(LibraryActivity.this,
 						PlayerService.class);
-				intent.setAction(PlayerService.ACTION_PLAY);
-				intent.putExtra(PlayerService.EXTRA_TRACK_ID,
-						(long) parent.getItemAtPosition(position));
+				intent.setAction(PlayerService.ACTION_PLAY)
+						.putExtra(PlayerService.EXTRA_TRACKS, trackIds)
+						.putExtra(PlayerService.EXTRA_START_POSITION, position);
 				startService(intent);
 
 				startActivity(new Intent(LibraryActivity.this,
@@ -131,11 +132,10 @@ public class LibraryActivity extends Activity {
 
 	/*
 	 * Load the contents of the library into a TextView with execute(). Work is
-	 * done in a background thread; the task displays a progress bar while
-	 * working.
+	 * done in a background thread.
 	 * 
-	 * The library is first deleted and rebuilt if `LoadTrackListTask.execute`
-	 * is called with a true parameter.
+	 * The library is first deleted and rebuilt if
+	 * `LoadTrackListTask.execute(true)` is called.
 	 */
 	private class LoadTrackListTask extends
 			AsyncTask<Boolean, Void, List<Long>> {
@@ -161,6 +161,14 @@ public class LibraryActivity extends Activity {
 					R.id.track_list_item, ids);
 
 			trackListView.setAdapter(adapter);
+
+			// Get a list of the track IDs as required for intent extras:
+			// there's no built-in means of converting these to primitives.
+			trackIds = new long[ids.size()];
+
+			for (int i = 0; i < trackIds.length; i++) {
+				trackIds[i] = ids.get(i);
+			}
 		}
 
 	}

--- a/vamp/src/pconley/vamp/PlayerActivity.java
+++ b/vamp/src/pconley/vamp/PlayerActivity.java
@@ -123,14 +123,12 @@ public class PlayerActivity extends Activity {
 
 		// Player may be null if an attentive user presses play/pause before the
 		// service is bound.
-		if (player == null) {
-			return;
-		}
-
-		if (player.isPlaying()) {
-			player.pause();
-		} else {
-			player.play();
+		if (player != null) {
+			if (player.isPlaying()) {
+				player.pause();
+			} else {
+				player.play();
+			}
 		}
 	}
 
@@ -225,7 +223,7 @@ public class PlayerActivity extends Activity {
 		}
 
 		/**
-		 * Clean up if the Player has been lost unexpectedly
+		 * Clean up if the Player has been lost unexpectedly.
 		 */
 		@Override
 		public void onServiceDisconnected(ComponentName name) {


### PR DESCRIPTION
Library sends a collection of tracks to the player when one is clicked (for now, it sends the entire library).

Also fixed several bugs:

- Crash if the now-playing activity registered its receiver to the player before the player had finished binding.
- Player wasn't fully reinitialized if I interrupted a playing track by selecting a new track.
- Warning about a mediaplayer with unhandled events if I released the player without resetting it (probably wouldn't cause any problems).
- Player gave an error if I tried to play/pause while no track was prepared (missing track, or after completion): distinguished Playing and Prepared states to resolve.