### PR TITLE
281 setting for path

### DIFF
--- a/vamp-test/src/pconley/vamp/db/test/LibraryHelperTest.java
+++ b/vamp-test/src/pconley/vamp/db/test/LibraryHelperTest.java
@@ -1,16 +1,18 @@
 package pconley.vamp.db.test;
 
-import pconley.vamp.db.LibraryHelper;
 import pconley.vamp.db.LibraryContract.TrackEntry;
+import pconley.vamp.db.LibraryHelper;
 import android.content.ContentValues;
+import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
+import android.preference.PreferenceManager;
 import android.test.AndroidTestCase;
 import android.test.RenamingDelegatingContext;
 
 /**
- * Test that the database helper class works correctly. Detailed tests are to
- * be reserved for DAOs.
+ * Test that the database helper class works correctly. Detailed tests are to be
+ * reserved for DAOs.
  */
 public class LibraryHelperTest extends AndroidTestCase {
 
@@ -22,8 +24,14 @@ public class LibraryHelperTest extends AndroidTestCase {
 	public void setUp() throws Exception {
 		super.setUp();
 
+		// TODO: instead, mock the call to PreferenceManager in LibraryHelper so
+		// settings aren't reset.
+		SharedPreferences preferences = PreferenceManager
+				.getDefaultSharedPreferences(getContext());
+		preferences.edit().clear().commit();
+
 		library = new LibraryHelper(new RenamingDelegatingContext(getContext(),
-					namePrefix)).getWritableDatabase();
+				namePrefix)).getWritableDatabase();
 	}
 
 	public void tearDown() throws Exception {
@@ -57,6 +65,5 @@ public class LibraryHelperTest extends AndroidTestCase {
 						.getColumnIndexOrThrow(TrackEntry.COLUMN_URI)));
 		contents.close();
 	}
-
 
 }

--- a/vamp-test/src/pconley/vamp/db/test/TrackDAOTest.java
+++ b/vamp-test/src/pconley/vamp/db/test/TrackDAOTest.java
@@ -13,9 +13,11 @@ import pconley.vamp.model.Tag;
 import pconley.vamp.model.Track;
 import android.content.ContentValues;
 import android.content.Context;
+import android.content.SharedPreferences;
 import android.database.Cursor;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
+import android.preference.PreferenceManager;
 import android.test.AndroidTestCase;
 import android.test.RenamingDelegatingContext;
 
@@ -42,6 +44,12 @@ public class TrackDAOTest extends AndroidTestCase {
 
 		Context context = new RenamingDelegatingContext(getContext(),
 				namePrefix);
+
+		// TODO: instead, mock the call to PreferenceManager in LibraryHelper so
+		// settings aren't reset.
+		SharedPreferences preferences = PreferenceManager
+				.getDefaultSharedPreferences(getContext());
+		preferences.edit().clear().commit();
 
 		library = new LibraryHelper(context).getWritableDatabase();
 		dao = new TrackDAO(context);

--- a/vamp/AndroidManifest.xml
+++ b/vamp/AndroidManifest.xml
@@ -34,13 +34,18 @@
                 android:value="pconley.vamp.LibraryActivity" />
         </activity>
 
-        <receiver android:name="pconley.vamp.player.AudioNoisyReceiver" >
+        <receiver android:name=".player.AudioNoisyReceiver" >
             <intent-filter>
                 <action android:name="android.media.AUDIO_BECOMING_NOISY" />
             </intent-filter>
         </receiver>
 
-        <service android:name="pconley.vamp.player.PlayerService" />
+        <service android:name=".player.PlayerService" />
+
+        <activity
+            android:name=".preferences.SettingsActivity"
+            android:label="@string/title_activity_settings" >
+        </activity>
     </application>
 
 </manifest>

--- a/vamp/res/layout/activity_library.xml
+++ b/vamp/res/layout/activity_library.xml
@@ -8,19 +8,9 @@
     android:paddingTop="@dimen/activity_vertical_margin"
     tools:context="pconley.vamp.LibraryActivity" >
 
-    <Button
-        android:id="@+id/button_create_library"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_marginBottom="@dimen/activity_vertical_margin"
-        android:onClick="createLibrary"
-        android:text="@string/create_library_text" />
-
     <ListView
         android:id="@+id/track_list"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:layout_below="@id/button_create_library" >
-    </ListView>
+        android:layout_height="wrap_content" />
 
 </RelativeLayout>

--- a/vamp/res/menu/library.xml
+++ b/vamp/res/menu/library.xml
@@ -7,5 +7,10 @@
         android:orderInCategory="1"
         android:showAsAction="ifRoom"
         android:title="@string/title_activity_player"/>
+    <item
+        android:id="@+id/action_settings"
+        android:orderInCategory="100"
+        android:showAsAction="never"
+        android:title="@string/title_activity_settings"/>
 
 </menu>

--- a/vamp/res/menu/player.xml
+++ b/vamp/res/menu/player.xml
@@ -2,4 +2,10 @@
     xmlns:tools="http://schemas.android.com/tools"
     tools:context="pconley.vamp.PlayerActivity" >
 
+    <item
+        android:id="@+id/action_settings"
+        android:orderInCategory="100"
+        android:showAsAction="never"
+        android:title="@string/title_activity_settings"/>
+
 </menu>

--- a/vamp/res/values/strings.xml
+++ b/vamp/res/values/strings.xml
@@ -12,5 +12,7 @@
     <string name="next">next</string>
     <string name="setting_library_path_title">Music Folder</string>
     <string name="setting_library_path_summary">Set the folder to scan for music</string>
+    <string name="setting_debug_title">Use Sample Library</string>
+    <string name="setting_debug_summary">Use a small library of sample tracks to aid debugging</string>
 
 </resources>

--- a/vamp/res/values/strings.xml
+++ b/vamp/res/values/strings.xml
@@ -3,12 +3,14 @@
 
     <string name="app_name">Android Music Player</string>
     <string name="title_activity_library">Library</string>
-    <string name="title_activity_track_view">Track Details</string>
     <string name="title_activity_player">Player</string>
+    <string name="title_activity_settings">Settings</string>
     <string name="create_library_text">Rebuild library</string>
     <string name="blank_time">0:00</string>
     <string name="play_pause">play/pause</string>
     <string name="previous">prev</string>
     <string name="next">next</string>
+    <string name="setting_library_path_title">Music Folder</string>
+    <string name="setting_library_path_summary">Set the folder to scan for music</string>
 
 </resources>

--- a/vamp/res/xml/preferences.xml
+++ b/vamp/res/xml/preferences.xml
@@ -1,11 +1,16 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
 
+    <SwitchPreference
+        android:defaultValue="false"
+        android:key="debug mode"
+        android:summary="@string/setting_debug_summary"
+        android:title="@string/setting_debug_title" />
+
     <EditTextPreference
-        android:key="library path"
-        android:title="@string/setting_library_path_title"
         android:defaultValue=""
+        android:key="library path"
         android:summary="@string/setting_library_path_summary"
-        />
+        android:title="@string/setting_library_path_title" />
 
 </PreferenceScreen>

--- a/vamp/res/xml/preferences.xml
+++ b/vamp/res/xml/preferences.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8"?>
+<PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android" >
+
+    <EditTextPreference
+        android:key="library path"
+        android:title="@string/setting_library_path_title"
+        android:defaultValue=""
+        android:summary="@string/setting_library_path_summary"
+        />
+
+</PreferenceScreen>

--- a/vamp/src/pconley/vamp/LibraryActivity.java
+++ b/vamp/src/pconley/vamp/LibraryActivity.java
@@ -5,6 +5,7 @@ import java.util.List;
 import pconley.vamp.db.TrackDAO;
 import pconley.vamp.player.PlayerEvent;
 import pconley.vamp.player.PlayerService;
+import pconley.vamp.preferences.SettingsActivity;
 import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.Context;
@@ -113,6 +114,9 @@ public class LibraryActivity extends Activity {
 		switch (item.getItemId()) {
 		case R.id.action_player:
 			startActivity(new Intent(this, PlayerActivity.class));
+			return true;
+		case R.id.action_settings:
+			startActivity(new Intent(this, SettingsActivity.class));
 			return true;
 		default:
 			return super.onOptionsItemSelected(item);

--- a/vamp/src/pconley/vamp/LibraryActivity.java
+++ b/vamp/src/pconley/vamp/LibraryActivity.java
@@ -14,7 +14,6 @@ import android.content.IntentFilter;
 import android.os.AsyncTask;
 import android.os.Bundle;
 import android.support.v4.content.LocalBroadcastManager;
-import android.util.Log;
 import android.view.Menu;
 import android.view.MenuItem;
 import android.view.View;
@@ -48,8 +47,7 @@ public class LibraryActivity extends Activity {
 			public void onReceive(Context context, Intent intent) {
 
 				if (intent.hasExtra(PlayerEvent.EXTRA_MESSAGE)) {
-					Toast.makeText(
-							LibraryActivity.this,
+					Toast.makeText(LibraryActivity.this,
 							intent.getStringExtra(PlayerEvent.EXTRA_MESSAGE),
 							Toast.LENGTH_LONG).show();
 				}
@@ -123,19 +121,6 @@ public class LibraryActivity extends Activity {
 		}
 	}
 
-	/**
-	 * Delete the contents of the library and replace it with sample contents.
-	 *
-	 * TODO: delete this (and the contents of the library) when I can read the
-	 * real thing.
-	 *
-	 * @param view
-	 *            The origin of the rebuild request
-	 */
-	public void createLibrary(View view) {
-		new LoadTrackListTask().execute(true);
-	}
-
 	/*
 	 * Load the contents of the library into a TextView with execute(). Work is
 	 * done in a background thread.
@@ -148,16 +133,6 @@ public class LibraryActivity extends Activity {
 
 		@Override
 		protected List<Long> doInBackground(Boolean... params) {
-			// Create a sample library.
-			if (params.length > 0 && params[0] == true) {
-				try {
-					Log.i("Library", "Rebuilding library");
-					TrackDAO.createSampleLibrary(LibraryActivity.this);
-				} catch (Exception e) {
-					Log.w("Library", e.getMessage());
-				}
-			}
-
 			return new TrackDAO(LibraryActivity.this).getIds();
 		}
 

--- a/vamp/src/pconley/vamp/PlayerActivity.java
+++ b/vamp/src/pconley/vamp/PlayerActivity.java
@@ -8,6 +8,7 @@ import java.util.TimeZone;
 import pconley.vamp.model.Track;
 import pconley.vamp.player.PlayerEvent;
 import pconley.vamp.player.PlayerService;
+import pconley.vamp.preferences.SettingsActivity;
 import android.app.Activity;
 import android.content.BroadcastReceiver;
 import android.content.ComponentName;
@@ -89,6 +90,9 @@ public class PlayerActivity extends Activity {
 	@Override
 	public boolean onOptionsItemSelected(MenuItem item) {
 		switch (item.getItemId()) {
+		case R.id.action_settings:
+			startActivity(new Intent(this, SettingsActivity.class));
+			return true;
 		default:
 			return super.onOptionsItemSelected(item);
 		}

--- a/vamp/src/pconley/vamp/db/LibraryHelper.java
+++ b/vamp/src/pconley/vamp/db/LibraryHelper.java
@@ -3,24 +3,48 @@ package pconley.vamp.db;
 import pconley.vamp.db.LibraryContract.TagEntry;
 import pconley.vamp.db.LibraryContract.TrackEntry;
 import pconley.vamp.db.LibraryContract.TrackTagRelation;
-
+import pconley.vamp.preferences.SettingsFragment;
+import android.content.ContentValues;
 import android.content.Context;
+import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.database.sqlite.SQLiteOpenHelper;
+import android.preference.PreferenceManager;
 
 public class LibraryHelper extends SQLiteOpenHelper {
 
 	private static final String DATABASE_NAME = "library.db";
+	private static final String DEBUG_DATABASE_NAME = "sample.db";
 	private static final int DATABASE_VERSION = 1;
 
+	private Context context;
+
+	/**
+	 * Create a helper object to open a database. If the settings item
+	 * "Use Sample Library" is set, then it replaces the database with a small,
+	 * prepopulated database of sample tracks.
+	 * 
+	 * @param context
+	 */
 	public LibraryHelper(Context context) {
-		super(context, DATABASE_NAME, null, DATABASE_VERSION);
+		super(
+				context,
+				PreferenceManager.getDefaultSharedPreferences(context)
+						.getBoolean(SettingsFragment.KEY_DEBUG, false) ? DEBUG_DATABASE_NAME
+						: DATABASE_NAME, null, DATABASE_VERSION);
+
+		this.context = context;
 	}
 
 	public void onCreate(SQLiteDatabase db) {
 		db.execSQL(TrackEntry.SQL_CREATE);
 		db.execSQL(TagEntry.SQL_CREATE);
 		db.execSQL(TrackTagRelation.SQL_CREATE);
+
+		if (PreferenceManager.getDefaultSharedPreferences(context).getBoolean(
+				SettingsFragment.KEY_DEBUG, false)) {
+			populateSampleLibrary(db);
+		}
 	}
 
 	@Override
@@ -32,6 +56,123 @@ public class LibraryHelper extends SQLiteOpenHelper {
 		super.onConfigure(db);
 
 		db.setForeignKeyConstraintsEnabled(true);
+	}
+
+	/**
+	 * Insert some sample tracks, and their tags into the database.
+	 *
+	 * @throws SQLException
+	 *             If any of the tracks or tags already exists in the database
+	 */
+	private void populateSampleLibrary(SQLiteDatabase db) throws SQLException {
+
+		// Hardcoded path: applies to my device only
+		final String musicPath = "file:///storage/extSdCard/Music/";
+
+		// Insert several tracks
+		long[] trackIds = new long[13];
+		String[] uris = new String[] {
+				// Test: MP4 tracks with "standard" tags
+				musicPath
+						+ "popular/They Might Be Giants/They Might Be Giants/01 Everything Right Is Wrong Again.m4a",
+				musicPath
+						+ "popular/They Might Be Giants/They Might Be Giants/02 Put Your Hand Inside the Puppet Head.m4a",
+				musicPath
+						+ "popular/They Might Be Giants/They Might Be Giants/03 Number Three.m4a",
+				musicPath
+						+ "popular/They Might Be Giants/They Might Be Giants/17 Alienation's for the Rich.m4a",
+				musicPath
+						+ "popular/They Might Be Giants/They Might Be Giants/18 The Day.m4a",
+				musicPath
+						+ "popular/They Might Be Giants/They Might Be Giants/19 Rhythm Section Want Ad.m4a",
+				// Test: Ogg Vorbis tracks with unusual metadata
+				musicPath
+						+ "classical/Schoenberg, Arnold (1874-1951)/Concerto for Violin and Orchestra, op 36/00-01 Poco allegro.ogg",
+				musicPath
+						+ "classical/Schoenberg, Arnold (1874-1951)/Concerto for Violin and Orchestra, op 36/00-02 Andante grazioso.ogg",
+				musicPath
+						+ "classical/Schoenberg, Arnold (1874-1951)/Concerto for Violin and Orchestra, op 36/00-03 Finale Allegro.ogg",
+				musicPath
+						+ "classical/Sibelius, Jean (1865-1957)/Concerto for Violin and Orchestra in D minor, Op. 47/00-04 Allegro moderato.ogg",
+				musicPath
+						+ "classical/Sibelius, Jean (1865-1957)/Concerto for Violin and Orchestra in D minor, Op. 47/00-05 Adagio di molto.ogg",
+				musicPath
+						+ "classical/Sibelius, Jean (1865-1957)/Concerto for Violin and Orchestra in D minor, Op. 47/00-06 Allegro, ma non tanto.ogg",
+				// Test: missing track
+				musicPath
+						+ "popular/Elvis Presley/Girls! Girls! Girls!/Return to Sender.mp3", };
+
+		for (int i = 0; i < uris.length; i++) {
+			ContentValues value = new ContentValues();
+			value.put(TrackEntry.COLUMN_URI, uris[i]);
+			trackIds[i] = db.insertOrThrow(TrackEntry.NAME, null, value);
+		}
+
+		// Insert the tracks' tags
+		long[] tagIds = new long[45];
+		String[] tagNames = new String[] { "artist", "composer", "album",
+				"genre", "discnumber", "year", "albumartist", "title", "title",
+				"title", "title", "title", "title", "tracknumber",
+				"tracknumber", "tracknumber", "tracknumber", "tracknumber",
+				"tracknumber", "conductor", "genre", "genre", "performer",
+				"date", "album", "ensemble", "artist", "label", "genre",
+				"composer", "title", "opus", "part", "part", "part", "genre",
+				"composer", "title", "opus", "part", "part", "part",
+				"tracknumber", "tracknumber", "tracknumber" };
+		String[] tagValues = new String[] { "They Might Be Giants",
+				"They Might Be Giants", "They Might Be Giants",
+				"Rock - Alternative", "1", "1986", "They Might Be Giants",
+				"Everything Right Is Wrong Again",
+				"Put Your Hand Inside the Puppet Head", "Number Three",
+				"Alienation's for the Rich", "The Day",
+				"Rhythm Section Want Ad", "1", "2", "3", "17", "18", "19",
+				"Esa-Pekka Salonen", "Violin", "Concerto",
+				"Hilary Hahn (Violin)", "2008-01-01",
+				"Schoenberg/Sibelius · Violin Concertos",
+				"Swedish Radio Symphony Orchestra",
+				"Hilary Hahn/Swedish Radio Symph. Orch.", "Deutsch Grammophon",
+				"20th Century", "Schoenberg, Arnold",
+				"Concerto for Violin and Orchestra", "36", "Poco allegro",
+				"Andante grazioso", "Finale Allegro", "Late Romantic",
+				"Sibelius, Jean",
+				"Concerto for Violin and Orchestra in D minor", "47",
+				"Allegro moderato", "Adagio di molto", "Allegro, ma non tanto",
+				"4", "5", "6" };
+
+		for (int i = 0; i < tagNames.length; i++) {
+			ContentValues value = new ContentValues();
+			value.put(TagEntry.COLUMN_TAG, tagNames[i]);
+			value.put(TagEntry.COLUMN_VAL, tagValues[i]);
+			tagIds[i] = db.insertOrThrow(TagEntry.NAME, null, value);
+		}
+
+		// Relate the tracks to their tags
+		int[] tracks = new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
+				1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3,
+				4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6,
+				6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7,
+				7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
+				9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10,
+				10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11,
+				11, 11, 11, 11, 11, 11, 11, 11, 11, 11 };
+
+		int[] tags = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 13, 0, 1, 2, 3, 4, 5,
+				6, 8, 14, 0, 1, 2, 3, 4, 5, 6, 9, 15, 0, 1, 2, 3, 4, 5, 6, 10,
+				16, 0, 1, 2, 3, 4, 5, 6, 11, 17, 0, 1, 2, 3, 4, 5, 6, 12, 18,
+				19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 13, 19,
+				20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 33, 14, 19, 20,
+				21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 34, 15, 19, 20, 21,
+				22, 23, 24, 25, 26, 27, 35, 36, 37, 38, 39, 42, 19, 20, 21, 22,
+				23, 24, 25, 26, 27, 35, 36, 37, 38, 40, 43, 19, 20, 21, 22, 23,
+				24, 25, 26, 27, 35, 36, 37, 38, 41, 44, };
+
+		for (int i = 0; i < tracks.length; i++) {
+			ContentValues value = new ContentValues();
+			value.put(TrackTagRelation.TRACK_ID, trackIds[tracks[i]]);
+			value.put(TrackTagRelation.TAG_ID, tagIds[tags[i]]);
+			db.insertOrThrow(TrackTagRelation.NAME, null, value);
+		}
+
 	}
 
 }

--- a/vamp/src/pconley/vamp/db/TrackDAO.java
+++ b/vamp/src/pconley/vamp/db/TrackDAO.java
@@ -8,11 +8,8 @@ import pconley.vamp.db.LibraryContract.TrackEntry;
 import pconley.vamp.db.LibraryContract.TrackTagRelation;
 import pconley.vamp.model.Tag;
 import pconley.vamp.model.Track;
-import android.annotation.SuppressLint;
-import android.content.ContentValues;
 import android.content.Context;
 import android.database.Cursor;
-import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 import android.net.Uri;
 
@@ -99,129 +96,6 @@ public class TrackDAO {
 		results.close();
 
 		return builder.build();
-	}
-
-	/**
-	 * Insert some sample tracks, and their tags into the database.
-	 *
-	 * @throws SQLException
-	 *             If any of the tracks or tags already exists in the database
-	 */
-	@SuppressLint("SdCardPath")
-	public static void createSampleLibrary(Context context) throws SQLException {
-		SQLiteDatabase library = new LibraryHelper(context)
-				.getWritableDatabase();
-		library.execSQL("delete from TrackHasTags");
-		library.execSQL("delete from Tags");
-		library.execSQL("delete from Tracks");
-
-		// Hardcoded path: applies to my device only
-		final String libPath = "file:///storage/extSdCard/Music/";
-
-		// Insert several tracks
-		long[] trackIds = new long[13];
-		String[] uris = new String[] {
-				// Test: MP4 tracks with "standard" tags
-				libPath
-						+ "popular/They Might Be Giants/They Might Be Giants/01 Everything Right Is Wrong Again.m4a",
-				libPath
-						+ "popular/They Might Be Giants/They Might Be Giants/02 Put Your Hand Inside the Puppet Head.m4a",
-				libPath
-						+ "popular/They Might Be Giants/They Might Be Giants/03 Number Three.m4a",
-				libPath
-						+ "popular/They Might Be Giants/They Might Be Giants/17 Alienation's for the Rich.m4a",
-				libPath
-						+ "popular/They Might Be Giants/They Might Be Giants/18 The Day.m4a",
-				libPath
-						+ "popular/They Might Be Giants/They Might Be Giants/19 Rhythm Section Want Ad.m4a",
-				// Test: Ogg Vorbis tracks with unusual metadata
-				libPath
-						+ "classical/Schoenberg, Arnold (1874-1951)/Concerto for Violin and Orchestra, op 36/00-01 Poco allegro.ogg",
-				libPath
-						+ "classical/Schoenberg, Arnold (1874-1951)/Concerto for Violin and Orchestra, op 36/00-02 Andante grazioso.ogg",
-				libPath
-						+ "classical/Schoenberg, Arnold (1874-1951)/Concerto for Violin and Orchestra, op 36/00-03 Finale Allegro.ogg",
-				libPath
-						+ "classical/Sibelius, Jean (1865-1957)/Concerto for Violin and Orchestra in D minor, Op. 47/00-04 Allegro moderato.ogg",
-				libPath
-						+ "classical/Sibelius, Jean (1865-1957)/Concerto for Violin and Orchestra in D minor, Op. 47/00-05 Adagio di molto.ogg",
-				libPath
-						+ "classical/Sibelius, Jean (1865-1957)/Concerto for Violin and Orchestra in D minor, Op. 47/00-06 Allegro, ma non tanto.ogg",
-				// Test: missing track
-				libPath
-						+ "popular/Elvis Presley/Girls! Girls! Girls!/Return to Sender.mp3", };
-
-		for (int i = 0; i < uris.length; i++) {
-			ContentValues value = new ContentValues();
-			value.put(TrackEntry.COLUMN_URI, uris[i]);
-			trackIds[i] = library.insertOrThrow(TrackEntry.NAME, null, value);
-		}
-
-		// Insert the tracks' tags
-		long[] tagIds = new long[45];
-		String[] tagNames = new String[] { "artist", "composer", "album",
-				"genre", "discnumber", "year", "albumartist", "title", "title",
-				"title", "title", "title", "title", "tracknumber",
-				"tracknumber", "tracknumber", "tracknumber", "tracknumber",
-				"tracknumber", "conductor", "genre", "genre", "performer",
-				"date", "album", "ensemble", "artist", "label", "genre",
-				"composer", "title", "opus", "part", "part", "part", "genre",
-				"composer", "title", "opus", "part", "part", "part",
-				"tracknumber", "tracknumber", "tracknumber" };
-		String[] tagValues = new String[] { "They Might Be Giants",
-				"They Might Be Giants", "They Might Be Giants",
-				"Rock - Alternative", "1", "1986", "They Might Be Giants",
-				"Everything Right Is Wrong Again",
-				"Put Your Hand Inside the Puppet Head", "Number Three",
-				"Alienation's for the Rich", "The Day",
-				"Rhythm Section Want Ad", "1", "2", "3", "17", "18", "19",
-				"Esa-Pekka Salonen", "Violin", "Concerto",
-				"Hilary Hahn (Violin)", "2008-01-01",
-				"Schoenberg/Sibelius · Violin Concertos",
-				"Swedish Radio Symphony Orchestra",
-				"Hilary Hahn/Swedish Radio Symph. Orch.", "Deutsch Grammophon",
-				"20th Century", "Schoenberg, Arnold",
-				"Concerto for Violin and Orchestra", "36", "Poco allegro",
-				"Andante grazioso", "Finale Allegro", "Late Romantic",
-				"Sibelius, Jean",
-				"Concerto for Violin and Orchestra in D minor", "47",
-				"Allegro moderato", "Adagio di molto", "Allegro, ma non tanto",
-				"4", "5", "6" };
-
-		for (int i = 0; i < tagNames.length; i++) {
-			ContentValues value = new ContentValues();
-			value.put(TagEntry.COLUMN_TAG, tagNames[i]);
-			value.put(TagEntry.COLUMN_VAL, tagValues[i]);
-			tagIds[i] = library.insertOrThrow(TagEntry.NAME, null, value);
-		}
-
-		// Relate the tracks to their tags
-		int[] tracks = new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 1, 1, 1, 1,
-				1, 1, 1, 2, 2, 2, 2, 2, 2, 2, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3, 3,
-				4, 4, 4, 4, 4, 4, 4, 4, 4, 5, 5, 5, 5, 5, 5, 5, 5, 5, 6, 6, 6,
-				6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 6, 7, 7, 7, 7, 7, 7, 7, 7, 7,
-				7, 7, 7, 7, 7, 7, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8, 8,
-				9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 9, 10, 10, 10, 10,
-				10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 10, 11, 11, 11, 11, 11,
-				11, 11, 11, 11, 11, 11, 11, 11, 11, 11 };
-
-		int[] tags = new int[] { 0, 1, 2, 3, 4, 5, 6, 7, 13, 0, 1, 2, 3, 4, 5,
-				6, 8, 14, 0, 1, 2, 3, 4, 5, 6, 9, 15, 0, 1, 2, 3, 4, 5, 6, 10,
-				16, 0, 1, 2, 3, 4, 5, 6, 11, 17, 0, 1, 2, 3, 4, 5, 6, 12, 18,
-				19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 13, 19,
-				20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 33, 14, 19, 20,
-				21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 34, 15, 19, 20, 21,
-				22, 23, 24, 25, 26, 27, 35, 36, 37, 38, 39, 42, 19, 20, 21, 22,
-				23, 24, 25, 26, 27, 35, 36, 37, 38, 40, 43, 19, 20, 21, 22, 23,
-				24, 25, 26, 27, 35, 36, 37, 38, 41, 44, };
-
-		for (int i = 0; i < tracks.length; i++) {
-			ContentValues value = new ContentValues();
-			value.put(TrackTagRelation.TRACK_ID, trackIds[tracks[i]]);
-			value.put(TrackTagRelation.TAG_ID, tagIds[tags[i]]);
-			library.insertOrThrow(TrackTagRelation.NAME, null, value);
-		}
-
 	}
 
 }

--- a/vamp/src/pconley/vamp/preferences/SettingsActivity.java
+++ b/vamp/src/pconley/vamp/preferences/SettingsActivity.java
@@ -1,0 +1,16 @@
+package pconley.vamp.preferences;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+public class SettingsActivity extends Activity {
+
+	@Override
+	protected void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+
+		getFragmentManager().beginTransaction()
+				.replace(android.R.id.content, new SettingsFragment()).commit();
+	}
+
+}

--- a/vamp/src/pconley/vamp/preferences/SettingsFragment.java
+++ b/vamp/src/pconley/vamp/preferences/SettingsFragment.java
@@ -1,0 +1,60 @@
+package pconley.vamp.preferences;
+
+import java.io.File;
+
+import pconley.vamp.R;
+import android.os.Bundle;
+import android.preference.EditTextPreference;
+import android.preference.Preference;
+import android.preference.PreferenceFragment;
+import android.text.InputType;
+import android.widget.Toast;
+
+public class SettingsFragment extends PreferenceFragment {
+
+	public static final String KEY_LIBRARY_PATH = "library path";
+
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+
+		addPreferencesFromResource(R.xml.preferences);
+
+		// Configure the library path preference item. Input is a single line of
+		// possibly non-English text, which must point to a valid, readable
+		// directory.
+		EditTextPreference libraryPathPref = (EditTextPreference) getPreferenceScreen()
+				.findPreference(KEY_LIBRARY_PATH);
+
+		libraryPathPref.getEditText().setInputType(
+				InputType.TYPE_CLASS_TEXT
+						| InputType.TYPE_TEXT_FLAG_NO_SUGGESTIONS);
+		libraryPathPref
+				.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+
+					@Override
+					public boolean onPreferenceChange(Preference preference,
+							Object newValue) {
+
+						File path = new File((String) newValue);
+
+						String error = null;
+						if (!path.exists()) {
+							error = "Path does not exist";
+						} else if (!path.isDirectory()) {
+							error = "Path doesn't point to a folder";
+						} else if (!path.canExecute()) {
+							error = "Directory contents aren't readable";
+						}
+
+						if (error != null) {
+							Toast.makeText(getActivity(), error,
+									Toast.LENGTH_LONG).show();
+							return false;
+						}
+
+						return true;
+					}
+				});
+	}
+}

--- a/vamp/src/pconley/vamp/preferences/SettingsFragment.java
+++ b/vamp/src/pconley/vamp/preferences/SettingsFragment.java
@@ -13,6 +13,7 @@ import android.widget.Toast;
 public class SettingsFragment extends PreferenceFragment {
 
 	public static final String KEY_LIBRARY_PATH = "library path";
+	public static final String KEY_DEBUG = "debug mode";
 
 	@Override
 	public void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
Added settings containing

- a path to the music folder (entered as text, because file browsers are more complex than I need now)
- a toggle between the regular database and the sample database I've been using. Activities must be redrawn (eg. by relaunching the app) to use a new DB.