### PR TITLE
Player gets tracks from a singleton Playlist

### DIFF
--- a/vamp-test/src/pconley/vamp/scanner/test/FilesystemScannerTest.java
+++ b/vamp-test/src/pconley/vamp/scanner/test/FilesystemScannerTest.java
@@ -1,5 +1,6 @@
 package pconley.vamp.scanner.test;
 
+import static android.test.MoreAsserts.assertContentsInAnyOrder;
 import static android.test.MoreAsserts.assertEmpty;
 
 import java.io.File;
@@ -129,7 +130,7 @@ public class FilesystemScannerTest extends InstrumentationTestCase {
 
 		assertEquals("No files are found in an empty directory", 0, count);
 		assertEmpty("No files are scanned from an empty directory",
-				dao.getIds());
+				dao.getTracks());
 	}
 
 	/**
@@ -155,7 +156,7 @@ public class FilesystemScannerTest extends InstrumentationTestCase {
 		assertEquals("A non-media file is counted", 1, count);
 		assertEmpty(
 				"No files are scanned from a directory with no media files",
-				dao.getIds());
+				dao.getTracks());
 
 	}
 
@@ -182,11 +183,8 @@ public class FilesystemScannerTest extends InstrumentationTestCase {
 
 		assertEquals("One file is found", 1, count);
 
-		List<Long> ids = dao.getIds();
-		assertEquals("One file is scanned", 1, ids.size());
-
-		Track track = dao.getTrack(ids.get(0));
-		assertEquals("The Ogg Vorbis file was scanned", expected, track);
+		assertEquals("The Ogg Vorbis file was scanned",
+				Arrays.asList(new Track[] { expected }), dao.getTracks());
 	}
 
 	/**
@@ -203,7 +201,7 @@ public class FilesystemScannerTest extends InstrumentationTestCase {
 		scanner.scanMusicFolder();
 
 		// Then
-		assertEmpty("Database is emptied before scanning", dao.getIds());
+		assertEmpty("Database is emptied before scanning", dao.getTracks());
 
 	}
 
@@ -231,11 +229,8 @@ public class FilesystemScannerTest extends InstrumentationTestCase {
 
 		assertEquals("Media and non-media files are counted", 2, count);
 
-		List<Long> ids = dao.getIds();
-		assertEquals("One file is scanned", 1, ids.size());
-
-		Track track = dao.getTrack(ids.get(0));
-		assertEquals("The Ogg Vorbis file was scanned", expected, track);
+		assertEquals("The Ogg Vorbis file was scanned",
+				Arrays.asList(new Track[] { expected }), dao.getTracks());
 	}
 
 	/**
@@ -244,10 +239,10 @@ public class FilesystemScannerTest extends InstrumentationTestCase {
 	 */
 	public void testTwoFiles() throws IOException, InterruptedException {
 		// Given
-		Track expected1 = AssetUtils.addAssetToFolder(testContext,
-				AssetUtils.OGG, new File(musicFolder, "sample_1.ogg"));
-		Track expected2 = AssetUtils.addAssetToFolder(testContext,
-				AssetUtils.OGG, new File(musicFolder, "sample_2.ogg"));
+		Track exp1 = AssetUtils.addAssetToFolder(testContext, AssetUtils.OGG,
+				new File(musicFolder, "sample_1.ogg"));
+		Track exp2 = AssetUtils.addAssetToFolder(testContext, AssetUtils.OGG,
+				new File(musicFolder, "sample_2.ogg"));
 
 		// When
 		int count = scanner.countMusicFiles();
@@ -263,19 +258,8 @@ public class FilesystemScannerTest extends InstrumentationTestCase {
 
 		assertEquals("Multiple media files are counted", 2, count);
 
-		List<Long> ids = dao.getIds();
-		assertEquals("Two files are scanned", 2, ids.size());
-
-		Track track = dao.getTrack(ids.get(0));
-		if (track.getUri().toString().endsWith("sample_1.ogg")) {
-			assertEquals("First file is correct", expected1, track);
-			assertEquals("Second file is correct", expected2,
-					dao.getTrack(ids.get(1)));
-		} else {
-			assertEquals("First file is correct", expected1,
-					dao.getTrack(ids.get(1)));
-			assertEquals("Second file is correct", expected2, track);
-		}
+		assertContentsInAnyOrder("Two files are scanned", dao.getTracks(),
+				exp1, exp2);
 	}
 
 	/**
@@ -299,7 +283,8 @@ public class FilesystemScannerTest extends InstrumentationTestCase {
 				Arrays.asList(new String[] { "", "sample" }), receivedDirs);
 
 		assertEquals("Directories are not counted", 0, count);
-		assertEmpty("No files are scanned in an empty directory", dao.getIds());
+		assertEmpty("No files are scanned in an empty directory",
+				dao.getTracks());
 	}
 
 	/**
@@ -329,11 +314,8 @@ public class FilesystemScannerTest extends InstrumentationTestCase {
 
 		assertEquals("Files in child directories are counted", 1, count);
 
-		List<Long> ids = dao.getIds();
-		assertEquals("One file is scanned", 1, ids.size());
-
-		Track track = dao.getTrack(ids.get(0));
-		assertEquals("The Ogg Vorbis file was scanned", expected, track);
+		assertEquals("The Ogg Vorbis file was scanned",
+				Arrays.asList(new Track[] { expected }), dao.getTracks());
 	}
 
 	/**
@@ -364,7 +346,7 @@ public class FilesystemScannerTest extends InstrumentationTestCase {
 		assertEmpty("No folders are recorded", receivedDirs);
 
 		assertEquals(".nomedia directories are not counted", 0, count);
-		assertEmpty(".nomedia is respected by the scanner", dao.getIds());
+		assertEmpty(".nomedia is respected by the scanner", dao.getTracks());
 	}
 
 	/**
@@ -397,13 +379,8 @@ public class FilesystemScannerTest extends InstrumentationTestCase {
 		assertEquals("Folders scanned are correct", singleDir, receivedDirs);
 
 		assertEquals(".nomedia child directories are not counted", 1, count);
-
-		List<Long> ids = dao.getIds();
-		assertEquals(".nomedia child directories are not scanned", 1,
-				ids.size());
-
-		Track track = dao.getTrack(ids.get(0));
-		assertEquals("The Ogg Vorbis file was scanned", expected, track);
+		assertEquals(".nomedia child directories are not scanned",
+				Arrays.asList(new Track[] { expected }), dao.getTracks());
 	}
 
 	public class ScannerBroadcastReceiver extends BroadcastReceiver {

--- a/vamp-test/src/pconley/vamp/scanner/test/ScannerServiceTest.java
+++ b/vamp-test/src/pconley/vamp/scanner/test/ScannerServiceTest.java
@@ -1,11 +1,9 @@
 package pconley.vamp.scanner.test;
 
-import static android.test.MoreAsserts.assertNotEmpty;
-
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
-import java.util.List;
+import java.util.Arrays;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 
@@ -188,10 +186,8 @@ public class ScannerServiceTest extends ServiceTestCase<ScannerService> {
 		assertEquals("Scan completed",
 				getContext().getString(R.string.scan_done), finalStatus);
 		dao.openReadableDatabase();
-		List<Long> ids = dao.getIds();
-		assertNotEmpty("Files have been scanned", ids);
-		assertEquals("Scanner writes to the library", expected,
-				dao.getTrack(ids.get(0)));
+		assertEquals("Scanner writes to the library",
+				Arrays.asList(new Track[] { expected }), dao.getTracks());
 
 	}
 

--- a/vamp-test/src/pconley/vamp/util/test/PlaylistTest.java
+++ b/vamp-test/src/pconley/vamp/util/test/PlaylistTest.java
@@ -21,15 +21,19 @@ public class PlaylistTest extends AndroidTestCase {
 
 	public void setUp() {
 		tracks = new LinkedList<Track>();
-		playlist = new Playlist();
 
 		for (int i = 0; i < 3; i++) {
 			Track track = new Track.Builder(i, Uri.parse(String.valueOf(i)))
 					.build();
 
 			tracks.add(track);
-			playlist.add(track);
 		}
+
+		playlist = new Playlist(tracks);
+	}
+
+	public void tearDown() {
+		Playlist.setInstance(null);
 	}
 
 	/**
@@ -46,6 +50,7 @@ public class PlaylistTest extends AndroidTestCase {
 	 * When I add several tracks to the playlist, then its size is correct.
 	 */
 	public void testPlaylistSize() {
+		assertNotEmpty(playlist);
 		assertEquals("Playlist has the correct size", tracks.size(),
 				playlist.size());
 	}
@@ -65,13 +70,34 @@ public class PlaylistTest extends AndroidTestCase {
 	}
 
 	/**
-	 * Given the playlist has several tracks, when I clear it, then it is marked
-	 * empty.
+	 * Given the playlist has been constructed from a list of tracks, when I
+	 * remove a track from the list, then the playlist is not modified.
 	 */
-	public void testClear() {
-		assertNotEmpty(playlist);
-		playlist.clear();
-		assertEmpty("Playlist is empty after clearing it", playlist);
+	public void testPlaylistSourceModified() {
+		// Given
+		playlist = new Playlist(tracks);
+		int expected = playlist.size();
+
+		// When
+		tracks.remove(0);
+
+		// Then
+		assertEquals("Playlist is not changed when its source is", expected,
+				playlist.size());
+	}
+
+	/**
+	 * When I set the global playlist and create a new playlist instance, then I
+	 * can recover the original global instance.
+	 */
+	public void testStaticInstanceIsPersistent() {
+		
+		// When
+		Playlist.setInstance(playlist);
+		new Playlist();
+		
+		// Then
+		assertSame("Global instance can be recovered", playlist, Playlist.getInstance());
 	}
 
 	/**

--- a/vamp/res/layout/fragment_scanner_progress.xml
+++ b/vamp/res/layout/fragment_scanner_progress.xml
@@ -9,11 +9,11 @@
         style="?android:attr/progressBarStyleHorizontal"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:indeterminate="true"
-        android:paddingTop="@dimen/generic_padding" />
+        android:indeterminate="true" />
 
     <TextView
         android:id="@+id/progress_comment"
+        android:minLines="2"
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:layout_below="@id/progress_bar"
@@ -25,9 +25,9 @@
         android:id="@+id/progress_totals"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
+        android:layout_alignParentRight="true"
         android:layout_below="@id/progress_bar"
         android:paddingLeft="@dimen/generic_padding"
-        android:layout_alignParentRight="true"
         android:textSize="@dimen/text_size" />
 
 </RelativeLayout>

--- a/vamp/res/values/strings.xml
+++ b/vamp/res/values/strings.xml
@@ -16,7 +16,6 @@
     <string name="player_error_MediaPlayer">Error %1$d,%2$d</string>
     <string name="player_error_read">Track %s could not be read</string>
     <string name="player_error_internal">Internal error %s</string>
-    <string name="player_error_invalid_playlist">Can\'t start: playlist has errors</string>
 
     <!-- Settings -->
     <string name="activity_settings_name">Settings</string>

--- a/vamp/src/pconley/vamp/util/Playlist.java
+++ b/vamp/src/pconley/vamp/util/Playlist.java
@@ -15,10 +15,50 @@ import pconley.vamp.library.model.Track;
  */
 public class Playlist implements Iterable<Track> {
 
+	private static Playlist instance;
+
 	private List<Track> tracks;
 
+	/**
+	 * Constructor for a local playlist
+	 */
 	public Playlist() {
-		tracks = new ArrayList<Track>();
+		this.tracks = new ArrayList<Track>();
+	}
+
+	/**
+	 * Constructor using a copy of a list.
+	 * 
+	 * @param tracks
+	 */
+	public Playlist(List<Track> tracks) {
+		this.tracks = new ArrayList<Track>(tracks);
+	}
+
+	/**
+	 * Get the global playlist able to be shared between activities.
+	 * 
+	 * @return The single global playlist
+	 */
+	public static Playlist getInstance() {
+		if (instance == null) {
+			instance = new Playlist();
+		}
+
+		return instance;
+	}
+
+	/**
+	 * Set a playlist to be used by the player.
+	 * 
+	 * @param playlist
+	 */
+	public static void setInstance(Playlist playlist) {
+		instance = playlist;
+	}
+
+	public void setTracks(List<Track> tracks) {
+		this.tracks = tracks;
 	}
 
 	/**
@@ -30,13 +70,6 @@ public class Playlist implements Iterable<Track> {
 	 */
 	public boolean add(Track track) {
 		return tracks.add(track);
-	}
-
-	/**
-	 * Remove all tracks in the playlist.
-	 */
-	public void clear() {
-		tracks.clear();
 	}
 
 	/**


### PR DESCRIPTION
LibraryActivity loads all data about all tracks on launch and adds it to
the playlist (negligibly slower than loading only IDs); PlayerService
has nothing to do (far faster than loading tracks by ID).

Library displays all tags as a side-effect.